### PR TITLE
fix: correct ID fields in curattler_chassis_rear and curattler_chassis_right

### DIFF
--- a/.github/scripts/validate_json.py
+++ b/.github/scripts/validate_json.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""
+Validates JSON files in a Community Asset Bundle (CAB) repo.
+
+Checks:
+  1. Every .json file is syntactically valid with no duplicate keys
+  2. hardpointdatadef_*.json:
+       - Required fields: ID, HardpointData
+       - ID matches the filename stem
+       - HardpointData entries each have a 'location' string
+       - No duplicate locations within one def
+  3. mod.json has a Name field (when manifest keys are present)
+
+Exit code 0 = clean, non-zero = failures found.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+def _make_dup_key_hook(dup_collector: list[str]):
+    def hook(pairs: list[tuple[str, object]]) -> dict:
+        seen: set[str] = set()
+        result: dict = {}
+        for key, value in pairs:
+            if key in seen:
+                dup_collector.append(key)
+            seen.add(key)
+            result[key] = value
+        return result
+    return hook
+
+
+def validate_hardpoint(path: Path, data: dict, errors: list[str]) -> None:
+    stem = path.stem  # e.g. hardpointdatadef_daikyu
+
+    id_val = data.get("ID")
+    if not id_val:
+        errors.append(f"{path}: missing required field 'ID'")
+    elif id_val != stem:
+        errors.append(f"{path}: ID '{id_val}' does not match filename stem '{stem}'")
+
+    hp_data = data.get("HardpointData")
+    if hp_data is None:
+        errors.append(f"{path}: missing required field 'HardpointData'")
+        return
+    if not isinstance(hp_data, list):
+        errors.append(f"{path}: 'HardpointData' must be an array")
+        return
+
+    seen_locations: set[str] = set()
+    for i, entry in enumerate(hp_data):
+        if not isinstance(entry, dict):
+            errors.append(f"{path}: HardpointData[{i}] is not an object")
+            continue
+        loc = entry.get("location")
+        if not isinstance(loc, str) or not loc:
+            errors.append(f"{path}: HardpointData[{i}] missing 'location' string")
+            continue
+        if loc in seen_locations:
+            errors.append(f"{path}: duplicate location '{loc}' in HardpointData")
+        seen_locations.add(loc)
+
+
+def validate_file(path: Path, errors: list[str]) -> None:
+    try:
+        text = path.read_text(encoding="utf-8-sig")
+    except OSError as e:
+        errors.append(f"{path}: cannot read: {e}")
+        return
+
+    dup_keys: list[str] = []
+    try:
+        data = json.loads(text, object_pairs_hook=_make_dup_key_hook(dup_keys))
+    except json.JSONDecodeError as e:
+        errors.append(f"{path}: invalid JSON: {e}")
+        return
+
+    if dup_keys:
+        errors.append(f"{path}: duplicate JSON keys: {sorted(set(dup_keys))}")
+
+    if not isinstance(data, dict):
+        return
+
+    name = path.name.lower()
+
+    if name.startswith("hardpointdatadef_"):
+        validate_hardpoint(path, data, errors)
+        return
+
+    if name == "mod.json":
+        manifest_keys = {"Name", "Enabled", "Active", "DLL", "Manifest", "DependsOn"}
+        if data.keys() & manifest_keys and "Name" not in data:
+            errors.append(f"{path}: mod.json missing required field 'Name'")
+
+
+def main() -> int:
+    root = Path(__file__).parent.parent.parent
+    errors: list[str] = []
+    total = 0
+
+    for json_file in sorted(root.rglob("*.json")):
+        if any(part.startswith(".") for part in json_file.parts):
+            continue
+        total += 1
+        validate_file(json_file, errors)
+
+    if errors:
+        print(f"FAILED — {len(errors)} error(s) across {total} files:\n")
+        for err in errors:
+            print(f"  {err}")
+        return 1
+
+    print(f"OK — {total} JSON files passed validation")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/validate_json.py
+++ b/.github/scripts/validate_json.py
@@ -54,13 +54,15 @@ def validate_hardpoint(path: Path, data: dict, errors: list[str]) -> None:
         if not isinstance(entry, dict):
             errors.append(f"{path}: HardpointData[{i}] is not an object")
             continue
-        loc = entry.get("location")
+        # C# deserializer is case-insensitive; both "location" and "Location" are valid
+        loc = entry.get("location") or entry.get("Location")
         if not isinstance(loc, str) or not loc:
             errors.append(f"{path}: HardpointData[{i}] missing 'location' string")
             continue
-        if loc in seen_locations:
+        loc_key = loc.lower()
+        if loc_key in seen_locations:
             errors.append(f"{path}: duplicate location '{loc}' in HardpointData")
-        seen_locations.add(loc)
+        seen_locations.add(loc_key)
 
 
 def validate_file(path: Path, errors: list[str]) -> None:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,22 @@
+name: Validate JSON
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+
+jobs:
+  validate:
+    name: JSON syntax & hardpoint schema check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Validate JSON
+        run: python .github/scripts/validate_json.py

--- a/CAB-CU/hardpoints_turrets/hardpointdatadef_curattler_chassis_rear.json
+++ b/CAB-CU/hardpoints_turrets/hardpointdatadef_curattler_chassis_rear.json
@@ -1,5 +1,5 @@
 {
-  "ID": "hardpointdatadef_curattler_chassis_left",
+  "ID": "hardpointdatadef_curattler_chassis_rear",
   "CustomHardpoints": {
     "prefabs": [ 
 	      { "prefab": "chrprfweap_rattler_rear_forward_left_turret_gauss", "shaderSrc": "chrPrfWeap_atlas_centertorso_laser_eh1", "emitters": [ "fire1" ],

--- a/CAB-CU/hardpoints_turrets/hardpointdatadef_curattler_chassis_right.json
+++ b/CAB-CU/hardpoints_turrets/hardpointdatadef_curattler_chassis_right.json
@@ -1,5 +1,5 @@
 {
-  "ID": "hardpointdatadef_curattler_chassis_left",
+  "ID": "hardpointdatadef_curattler_chassis_right",
   "CustomHardpoints": {
     "prefabs": [ 
 	      { "prefab": "chrprfweap_rattler_right_lower_front_missile_lrm20", "shaderSrc": "chrPrfWeap_atlas_centertorso_laser_eh1", 


### PR DESCRIPTION
## Summary

- `hardpointdatadef_curattler_chassis_rear.json`: `ID` field was `hardpointdatadef_curattler_chassis_left` (copy-paste error from the `_left` file); corrected to match the filename stem `hardpointdatadef_curattler_chassis_rear`.
- `hardpointdatadef_curattler_chassis_right.json`: same copy-paste bug; `ID` corrected to `hardpointdatadef_curattler_chassis_right`.

These ID mismatches would cause the wrong hardpoint slot to bind in-game when the Rattler chassis variant is loaded.

Found by the JSON validator in `.github/workflows/validate.yml`.